### PR TITLE
Move rapla result parsing into separate isolate

### DIFF
--- a/lib/common/appstart/app_initializer.dart
+++ b/lib/common/appstart/app_initializer.dart
@@ -25,7 +25,7 @@ Future<void> initializeApp(bool isBackground) async {
 
   WidgetsFlutterBinding.ensureInitialized();
 
-  injectServices();
+  injectServices(isBackground);
 
   if (isBackground) {
     await LocalizationInitialize.fromPreferences(KiwiContainer().resolve())

--- a/lib/common/appstart/service_injector.dart
+++ b/lib/common/appstart/service_injector.dart
@@ -12,6 +12,7 @@ import 'package:dhbwstudentapp/schedule/business/schedule_source_setup.dart';
 import 'package:dhbwstudentapp/schedule/data/schedule_entry_repository.dart';
 import 'package:dhbwstudentapp/schedule/data/schedule_query_information_repository.dart';
 import 'package:dhbwstudentapp/schedule/service/error_report_schedule_source_decorator.dart';
+import 'package:dhbwstudentapp/schedule/service/isolate_schedule_source_decorator.dart';
 import 'package:dhbwstudentapp/schedule/service/rapla/rapla_schedule_source.dart';
 import 'package:dhbwstudentapp/schedule/service/schedule_source.dart';
 import 'package:kiwi/kiwi.dart';
@@ -31,7 +32,9 @@ void injectServices() {
     SecureStorageAccess(),
   ));
   c.registerInstance<ScheduleSource>(
-    ErrorReportScheduleSourceDecorator(RaplaScheduleSource()),
+    IsolateScheduleSourceDecorator(
+      ErrorReportScheduleSourceDecorator(RaplaScheduleSource()),
+    ),
   );
   c.registerInstance(DatabaseAccess());
   c.registerInstance(ScheduleEntryRepository(

--- a/lib/common/appstart/service_injector.dart
+++ b/lib/common/appstart/service_injector.dart
@@ -23,7 +23,7 @@ bool _isInjected = false;
 /// This function injects all instances into the KiwiContainer. You can get a
 /// singleton instance of a registered type using KiwiContainer().resolve()
 ///
-void injectServices() {
+void injectServices(bool isBackground) {
   if (_isInjected) return;
 
   KiwiContainer c = KiwiContainer();
@@ -32,9 +32,11 @@ void injectServices() {
     SecureStorageAccess(),
   ));
   c.registerInstance<ScheduleSource>(
-    IsolateScheduleSourceDecorator(
-      ErrorReportScheduleSourceDecorator(RaplaScheduleSource()),
-    ),
+    isBackground
+        ? ErrorReportScheduleSourceDecorator(RaplaScheduleSource())
+        : IsolateScheduleSourceDecorator(
+            ErrorReportScheduleSourceDecorator(RaplaScheduleSource()),
+          ),
   );
   c.registerInstance(DatabaseAccess());
   c.registerInstance(ScheduleEntryRepository(

--- a/lib/schedule/service/isolate_schedule_source_decorator.dart
+++ b/lib/schedule/service/isolate_schedule_source_decorator.dart
@@ -1,0 +1,100 @@
+import 'dart:async';
+import 'dart:isolate';
+
+import 'package:dhbwstudentapp/common/util/cancellation_token.dart';
+import 'package:dhbwstudentapp/schedule/model/schedule.dart';
+import 'package:dhbwstudentapp/schedule/service/schedule_source.dart';
+
+scheduleSourceIsolateEntryPoint(SendPort sendPort) async {
+  var port = ReceivePort();
+  sendPort.send(port.sendPort);
+
+  CancellationToken token;
+
+  await for (var message in port) {
+    if (message["type"] == "execute") {
+      token = CancellationToken();
+      executeQuerySchedule(message, sendPort, token);
+    } else if (message["type"] == "cancel") {
+      token?.cancel();
+    }
+  }
+}
+
+Future<void> executeQuerySchedule(
+  Map<String, dynamic> map,
+  SendPort sendPort,
+  CancellationToken token,
+) async {
+  try {
+    ScheduleSource source = map["source"];
+    DateTime from = map["from"];
+    DateTime to = map["to"];
+
+    var result = await source.querySchedule(from, to, token);
+
+    sendPort.send(result);
+  } on OperationCancelledException catch (_) {
+    sendPort.send(null);
+  }
+}
+
+class IsolateScheduleSourceDecorator extends ScheduleSource {
+  final ScheduleSource _scheduleSource;
+
+  Stream _isolateToMain;
+  Isolate _isolate;
+  SendPort _sendPort;
+
+  IsolateScheduleSourceDecorator(this._scheduleSource);
+
+  @override
+  Future<Schedule> querySchedule(DateTime from, DateTime to,
+      [CancellationToken cancellationToken]) async {
+    await _initializeIsolate();
+
+    cancellationToken.setCancellationCallback(() {
+      _sendPort.send({"type": "cancel"});
+    });
+
+    _sendPort.send({
+      "type": "execute",
+      "source": _scheduleSource,
+      "from": from,
+      "to": to,
+    });
+
+    final completer = Completer<Schedule>();
+    final subscription = _isolateToMain.listen((result) {
+      cancellationToken.setCancellationCallback(null);
+      completer.complete(result);
+    });
+
+    final result = await completer.future;
+    subscription.cancel();
+
+    return result;
+  }
+
+  Future<void> _initializeIsolate() async {
+    if (_isolate != null && _isolateToMain != null && _sendPort != null) return;
+
+    var isolateToMain = ReceivePort();
+
+    // Use a broadcast stream. The normal RecievePort closes after one subscription
+    _isolateToMain = isolateToMain.asBroadcastStream();
+    _isolate = await Isolate.spawn(
+        scheduleSourceIsolateEntryPoint, isolateToMain.sendPort);
+    _sendPort = await _isolateToMain.first;
+  }
+
+  @override
+  void setEndpointUrl(String url) {
+    _scheduleSource.setEndpointUrl(url);
+  }
+
+  @override
+  void validateEndpointUrl(String url) {
+    _scheduleSource.validateEndpointUrl(url);
+  }
+}

--- a/lib/schedule/ui/weeklyschedule/weekly_schedule_page.dart
+++ b/lib/schedule/ui/weeklyschedule/weekly_schedule_page.dart
@@ -74,23 +74,7 @@ class _WeeklySchedulePageState extends State<WeeklySchedulePage> {
               mainAxisAlignment: MainAxisAlignment.spaceEvenly,
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: <Widget>[
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: <Widget>[
-                    FlatButton(
-                      child: Icon(Icons.chevron_left),
-                      onPressed: _previousWeek,
-                    ),
-                    FlatButton(
-                      child: Icon(Icons.today),
-                      onPressed: _goToToday,
-                    ),
-                    FlatButton(
-                      child: Icon(Icons.chevron_right),
-                      onPressed: _nextWeek,
-                    ),
-                  ],
-                ),
+                _buildNavigationButtonBar(),
                 Expanded(
                   child: Stack(
                     children: <Widget>[
@@ -99,38 +83,38 @@ class _WeeklySchedulePageState extends State<WeeklySchedulePage> {
                         child: PropertyChangeConsumer(
                           properties: ["weekSchedule", "now"],
                           builder: (BuildContext context,
-                                  WeeklyScheduleViewModel model,
-                                  Set properties) =>
-                              PageTransitionSwitcher(
-                            reverse: !model.didUpdateScheduleIntoFuture,
-                            duration: Duration(milliseconds: 300),
-                            transitionBuilder: (Widget child,
-                                    Animation<double> animation,
-                                    Animation<double> secondaryAnimation) =>
-                                SharedAxisTransition(
-                              child: child,
-                              animation: animation,
-                              secondaryAnimation: secondaryAnimation,
-                              transitionType:
-                                  SharedAxisTransitionType.horizontal,
-                            ),
-                            child: ScheduleWidget(
-                              key: ValueKey(
-                                model.currentDateStart.toIso8601String(),
+                              WeeklyScheduleViewModel model, Set properties) {
+                            return PageTransitionSwitcher(
+                              reverse: !model.didUpdateScheduleIntoFuture,
+                              duration: Duration(milliseconds: 300),
+                              transitionBuilder: (Widget child,
+                                      Animation<double> animation,
+                                      Animation<double> secondaryAnimation) =>
+                                  SharedAxisTransition(
+                                child: child,
+                                animation: animation,
+                                secondaryAnimation: secondaryAnimation,
+                                transitionType:
+                                    SharedAxisTransitionType.horizontal,
                               ),
-                              schedule: model.weekSchedule,
-                              displayStart: model.clippedDateStart ??
-                                  model.currentDateStart,
-                              displayEnd:
-                                  model.clippedDateEnd ?? model.currentDateEnd,
-                              onScheduleEntryTap: (entry) {
-                                _onScheduleEntryTap(context, entry);
-                              },
-                              now: model.now,
-                              displayEndHour: model.displayEndHour,
-                              displayStartHour: model.displayStartHour,
-                            ),
-                          ),
+                              child: ScheduleWidget(
+                                key: ValueKey(
+                                  model.currentDateStart.toIso8601String(),
+                                ),
+                                schedule: model.weekSchedule,
+                                displayStart: model.clippedDateStart ??
+                                    model.currentDateStart,
+                                displayEnd: model.clippedDateEnd ??
+                                    model.currentDateEnd,
+                                onScheduleEntryTap: (entry) {
+                                  _onScheduleEntryTap(context, entry);
+                                },
+                                now: model.now,
+                                displayEndHour: model.displayEndHour,
+                                displayStartHour: model.displayStartHour,
+                              ),
+                            );
+                          },
                         ),
                       ),
                       PropertyChangeConsumer(
@@ -151,6 +135,26 @@ class _WeeklySchedulePageState extends State<WeeklySchedulePage> {
           ],
         ),
       ),
+    );
+  }
+
+  Row _buildNavigationButtonBar() {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: <Widget>[
+        FlatButton(
+          child: Icon(Icons.chevron_left),
+          onPressed: _previousWeek,
+        ),
+        FlatButton(
+          child: Icon(Icons.today),
+          onPressed: _goToToday,
+        ),
+        FlatButton(
+          child: Icon(Icons.chevron_right),
+          onPressed: _nextWeek,
+        ),
+      ],
     );
   }
 


### PR DESCRIPTION
When changing the week, there was jitter while the rapla result gets parsed. Moved the `querySchedule(...)` call to a separate isolate to decrease the work which has to be done on the main task.