### PR TITLE
fix: change url for eduroam

### DIFF
--- a/lib/information/ui/usefulinformation/useful_information_page.dart
+++ b/lib/information/ui/usefulinformation/useful_information_page.dart
@@ -49,7 +49,7 @@ class UsefulInformationPage extends StatelessWidget {
             title: Text(L.of(context).informationPageEduroam),
             onTap: () {
               openLink(
-                  "https://www.dhbw-stuttgart.de/themen/einrichtungen/itservice-center/informationen-fuer-studierende/wlan-vpn-zugang/");
+                  "https://www.dhbw-stuttgart.de/service/its/informationen-fuer-studierende/wlan/vpn-zugang/");
             },
           ),
           ListTile(


### PR DESCRIPTION
The URL for eduroam in the useful links is no longer valid.
Link has been corrected: [WLAN / VPN access](https://www.dhbw-stuttgart.de/service/its/informationen-fuer-studierende/wlan/vpn-zugang/)